### PR TITLE
session constructor that allows setting the callbacks before start_resolve is called

### DIFF
--- a/lib/asio_client_session.cc
+++ b/lib/asio_client_session.cc
@@ -44,6 +44,17 @@ session::session(boost::asio::io_service &io_service, const std::string &host,
   impl_->start_resolve(host, service);
 }
 
+session::session(boost::asio::io_service &io_service, const std::string &host,
+    const std::string &service,
+    connect_cb ccb,
+    error_cb ecb)
+    : impl_(std::make_shared<session_tcp_impl>(
+          io_service, host, service, boost::posix_time::seconds(60))) {
+  impl_->on_connect(std::move(ccb));
+  impl_->on_error(std::move(ecb)); 
+  impl_->start_resolve(host, service);
+}
+
 session::session(boost::asio::io_service &io_service,
                  const boost::asio::ip::tcp::endpoint &local_endpoint,
                  const std::string &host, const std::string &service)

--- a/lib/includes/nghttp2/asio_http2_client.h
+++ b/lib/includes/nghttp2/asio_http2_client.h
@@ -150,6 +150,11 @@ public:
   session(boost::asio::io_service &io_service, const std::string &host,
           const std::string &service);
 
+  session(boost::asio::io_service &io_service, const std::string &host,
+          const std::string &service,
+          connect_cb ccb,
+          error_cb ecb);
+
   // Same as previous but with pegged local endpoint
   session(boost::asio::io_service &io_service,
           const boost::asio::ip::tcp::endpoint &local_endpoint,


### PR DESCRIPTION
Using session  a situation where io_service is already running is problematic in that callbacks could only be set after start_resolve was already called by the constructor, leading to missed callbacks.

This commit adds a constructor signature that lets callbacks be set before resolution is started.